### PR TITLE
Fix dead link to cast documentation

### DIFF
--- a/cast/README.md
+++ b/cast/README.md
@@ -2,7 +2,7 @@
 
 **Need help with Cast? Read the [📖 Foundry Book (Cast Guide)][foundry-book-cast-guide] (WIP)!**
 
-[foundry-book-cast-guide]: https://onbjerg.github.io/foundry-book/cast/
+[foundry-book-cast-guide]: https://book.getfoundry.sh/cast/index.html
 
 ## Features
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Link to Cast section of foundry-book was dead / outdated. (error 404)


## Solution
Fix by adding link to: https://book.getfoundry.sh/cast/index.html
